### PR TITLE
Minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ import { say } from 'dectalk';
 Windows support was added recently, 
 if you have any problems dont be afraid to make an issue
 
+### Mac
+Unfortunately, Dectalk does not support macOS.
+If you would like to use this module on Mac, try running your project
+inside a Linux [Docker](https://www.docker.com/) container.
+
 ### Linux
 On my arch linux server (x86_64)
 i had to install some dependencies

--- a/dist/dectalk.d.ts
+++ b/dist/dectalk.d.ts
@@ -23,19 +23,17 @@ declare type DecOptions = {
     SpeakRate?: number;
     /**
      * (_Linux only_)
-     * The voice of who talks
+     * The voice of who talks. Default is 0
      *
-     * Here is what i think they are
-     *
-     * -> 0. Default voice
-     * 1. Female voice
-     * 2. Low pitch guy
-     * 3. Another Female voice?
-     * 4. Almost Default voice (a little lower pitch)
-     * 5. Female very high pitch
-     * 6. Female high pitch (like the previouse but lower)
-     * 7. Another male voice
-     * 8. Another female voice
+     * 0. Paul (male)
+     * 1. Betty (female)
+     * 2. Harry (male, low pitch)
+     * 3. Frank (male, high pitch and hoarse)
+     * 4. Dennis (male, nasally)
+     * 5. Kid (child, high pitch)
+     * 6. Ursula (female, high pitch)
+     * 7. Rita (female, nasally)
+     * 8. Wendy (female, low pitch and hoarse)
      *
      * Any other numbers defaults to the 0 voice
      */

--- a/dist/dectalk.d.ts
+++ b/dist/dectalk.d.ts
@@ -4,7 +4,31 @@ export declare enum WaveEncoding {
     PCM_8bits_MONO_11KHz = 2,
     MULAW_8bits_MONO_8KHz = 3
 }
-declare type DecOptions = {
+/**
+ * (_Linux only_)
+ * Different settings for voices.
+ */
+export declare enum Speaker {
+    /** Default male voice */
+    PAUL = 0,
+    /** Default female voice */
+    BETTY = 1,
+    /** Low-pitched male voice */
+    HARRY = 2,
+    /** High-pitched hoarse male voice */
+    FRANK = 3,
+    /** Nasally male voice */
+    DENNIS = 4,
+    /** High-pitched child voice */
+    KID = 5,
+    /** High-pitched female voice */
+    URSULA = 6,
+    /** Nasally female voice */
+    RITA = 7,
+    /** Low-pitched hoarse female voice */
+    WENDY = 8
+}
+export declare type DecOptions = {
     /**
      * (_Linux only_)
      * The encoding the wav file is
@@ -23,21 +47,9 @@ declare type DecOptions = {
     SpeakRate?: number;
     /**
      * (_Linux only_)
-     * The voice of who talks. Default is 0
-     *
-     * 0. Paul (male)
-     * 1. Betty (female)
-     * 2. Harry (male, low pitch)
-     * 3. Frank (male, high pitch and hoarse)
-     * 4. Dennis (male, nasally)
-     * 5. Kid (child, high pitch)
-     * 6. Ursula (female, high pitch)
-     * 7. Rita (female, nasally)
-     * 8. Wendy (female, low pitch and hoarse)
-     *
-     * Any other numbers defaults to the 0 voice
+     * The voice of who talks. Default is PAUL (0)
      */
-    SpeakerNumber?: number;
+    Speaker?: Speaker;
     /**
      * Enable phoname commands
      *
@@ -49,4 +61,3 @@ declare type DecOptions = {
     EnableCommands?: boolean;
 };
 export declare function say(content: string, options?: DecOptions): Promise<Buffer>;
-export {};

--- a/dist/dectalk.js
+++ b/dist/dectalk.js
@@ -66,9 +66,9 @@ function say(content, options) {
                             content = "[:PHONE ON]" + content;
                         }
                         args.push('-w', file.name);
-                        //args.push('-d', __dirname + "/../dtalk/dtalk_us.dic");
+                        //args.push('-d', __dirname + "\\..\\dtalk\\dtalk_us.dic");
                         args.push(content);
-                        dec = (0, node_child_process_1.spawn)(__dirname + '/../dtalk/windows/say.exe', args, { cwd: __dirname + '/../dtalk/windows' });
+                        dec = (0, node_child_process_1.spawn)(__dirname + '\\..\\dtalk\\windows\\say.exe', args, { cwd: __dirname + '\\..\\dtalk\\windows' });
                     }
                     //Linux / Others
                     else {

--- a/dist/dectalk.js
+++ b/dist/dectalk.js
@@ -92,7 +92,17 @@ function say(content, options) {
                         args.push('-fo', file.name);
                         dec = (0, node_child_process_1.spawn)(__dirname + '/../dtalk/linux/say_demo_us', args, { cwd: __dirname + '/../dtalk' });
                     }
-                    dec.on('close', function () {
+                    // Reject if dectalk failed to start
+                    dec.on('error', function (error) {
+                        rej("Failed to start dectalk\n" + error);
+                    });
+                    // Redirect dectalk output to the console
+                    dec.stdout.on('data', console.log);
+                    dec.stderr.on('data', console.error);
+                    dec.on('close', function (code) {
+                        // Reject if dectalk was not successful
+                        if (code !== 0)
+                            rej("Dectalk exited with code " + code);
                         res((0, node_fs_1.readFileSync)(file.name));
                     });
                 })];

--- a/dist/dectalk.js
+++ b/dist/dectalk.js
@@ -37,10 +37,10 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 };
 exports.__esModule = true;
 exports.say = exports.WaveEncoding = void 0;
-var child_process_1 = require("child_process");
-var fs_1 = require("fs");
-var tmp = require("tmp");
-var os = require("os");
+var node_child_process_1 = require("node:child_process");
+var node_fs_1 = require("node:fs");
+var node_os_1 = require("node:os");
+var tmp_1 = require("tmp");
 var WaveEncoding;
 (function (WaveEncoding) {
     WaveEncoding[WaveEncoding["PCM_16bits_MONO_11KHz"] = 1] = "PCM_16bits_MONO_11KHz";
@@ -51,10 +51,10 @@ function say(content, options) {
     return __awaiter(this, void 0, void 0, function () {
         return __generator(this, function (_a) {
             return [2 /*return*/, new Promise(function (res, rej) {
-                    var file = tmp.fileSync({ prefix: 'dectalk', postfix: '.wav' });
+                    var file = (0, tmp_1.fileSync)({ prefix: 'dectalk', postfix: '.wav' });
                     var dec;
                     //Windows
-                    if (os.platform() == "win32") {
+                    if ((0, node_os_1.platform)() == "win32") {
                         var args = [];
                         if (options) {
                             if (options.EnableCommands)
@@ -68,7 +68,7 @@ function say(content, options) {
                         args.push('-w', file.name);
                         //args.push('-d', __dirname + "/../dtalk/dtalk_us.dic");
                         args.push(content);
-                        dec = (0, child_process_1.spawn)(__dirname + '/../dtalk/windows/say.exe', args, { cwd: __dirname + '/../dtalk/windows' });
+                        dec = (0, node_child_process_1.spawn)(__dirname + '/../dtalk/windows/say.exe', args, { cwd: __dirname + '/../dtalk/windows' });
                     }
                     //Linux / Others
                     else {
@@ -90,10 +90,10 @@ function say(content, options) {
                         }
                         args.push('-a', content);
                         args.push('-fo', file.name);
-                        dec = (0, child_process_1.spawn)(__dirname + '/../dtalk/linux/say_demo_us', args, { cwd: __dirname + '/../dtalk' });
+                        dec = (0, node_child_process_1.spawn)(__dirname + '/../dtalk/linux/say_demo_us', args, { cwd: __dirname + '/../dtalk' });
                     }
                     dec.on('close', function () {
-                        res((0, fs_1.readFileSync)(file.name));
+                        res((0, node_fs_1.readFileSync)(file.name));
                     });
                 })];
         });

--- a/dist/dectalk.js
+++ b/dist/dectalk.js
@@ -53,7 +53,7 @@ function say(content, options) {
             return [2 /*return*/, new Promise(function (res, rej) {
                     var file = (0, tmp_1.fileSync)({ prefix: 'dectalk', postfix: '.wav' });
                     var dec;
-                    //Windows
+                    // Windows
                     if ((0, node_os_1.platform)() == "win32") {
                         var args = [];
                         if (options) {
@@ -70,7 +70,7 @@ function say(content, options) {
                         args.push(content);
                         dec = (0, node_child_process_1.spawn)(__dirname + '\\..\\dtalk\\windows\\say.exe', args, { cwd: __dirname + '\\..\\dtalk\\windows' });
                     }
-                    //Linux / Others
+                    // Linux / Others
                     else {
                         var args = [];
                         if (options) {

--- a/dist/dectalk.js
+++ b/dist/dectalk.js
@@ -36,7 +36,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 exports.__esModule = true;
-exports.say = exports.WaveEncoding = void 0;
+exports.say = exports.Speaker = exports.WaveEncoding = void 0;
 var node_child_process_1 = require("node:child_process");
 var node_fs_1 = require("node:fs");
 var node_os_1 = require("node:os");
@@ -47,6 +47,31 @@ var WaveEncoding;
     WaveEncoding[WaveEncoding["PCM_8bits_MONO_11KHz"] = 2] = "PCM_8bits_MONO_11KHz";
     WaveEncoding[WaveEncoding["MULAW_8bits_MONO_8KHz"] = 3] = "MULAW_8bits_MONO_8KHz";
 })(WaveEncoding = exports.WaveEncoding || (exports.WaveEncoding = {}));
+/**
+ * (_Linux only_)
+ * Different settings for voices.
+ */
+var Speaker;
+(function (Speaker) {
+    /** Default male voice */
+    Speaker[Speaker["PAUL"] = 0] = "PAUL";
+    /** Default female voice */
+    Speaker[Speaker["BETTY"] = 1] = "BETTY";
+    /** Low-pitched male voice */
+    Speaker[Speaker["HARRY"] = 2] = "HARRY";
+    /** High-pitched hoarse male voice */
+    Speaker[Speaker["FRANK"] = 3] = "FRANK";
+    /** Nasally male voice */
+    Speaker[Speaker["DENNIS"] = 4] = "DENNIS";
+    /** High-pitched child voice */
+    Speaker[Speaker["KID"] = 5] = "KID";
+    /** High-pitched female voice */
+    Speaker[Speaker["URSULA"] = 6] = "URSULA";
+    /** Nasally female voice */
+    Speaker[Speaker["RITA"] = 7] = "RITA";
+    /** Low-pitched hoarse female voice */
+    Speaker[Speaker["WENDY"] = 8] = "WENDY";
+})(Speaker = exports.Speaker || (exports.Speaker = {}));
 function say(content, options) {
     return __awaiter(this, void 0, void 0, function () {
         return __generator(this, function (_a) {
@@ -82,8 +107,8 @@ function say(content, options) {
                                 args.push('-e', options.WaveEncoding.toString());
                             if (options.SpeakRate)
                                 args.push('-r', options.SpeakRate.toString());
-                            if (options.SpeakerNumber)
-                                args.push('-s', options.SpeakerNumber.toString());
+                            if (options.Speaker)
+                                args.push('-s', options.Speaker.toString());
                             if (options.EnableCommands)
                                 content = "[:PHONE ON]" + content;
                         }

--- a/dist/dectalk.js
+++ b/dist/dectalk.js
@@ -54,7 +54,7 @@ function say(content, options) {
                     var file = (0, tmp_1.fileSync)({ prefix: 'dectalk', postfix: '.wav' });
                     var dec;
                     // Windows
-                    if ((0, node_os_1.platform)() == "win32") {
+                    if ((0, node_os_1.platform)() === "win32") {
                         var args = [];
                         if (options) {
                             if (options.EnableCommands)
@@ -70,7 +70,11 @@ function say(content, options) {
                         args.push(content);
                         dec = (0, node_child_process_1.spawn)(__dirname + '\\..\\dtalk\\windows\\say.exe', args, { cwd: __dirname + '\\..\\dtalk\\windows' });
                     }
-                    // Linux / Others
+                    // Mac is NOT supported
+                    else if ((0, node_os_1.platform)() === "darwin") {
+                        rej('Dectalk is not supported on Mac');
+                    }
+                    // Linux
                     else {
                         var args = [];
                         if (options) {

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,1 +1,1 @@
-export { say } from './dectalk';
+export { WaveEncoding, Speaker, DecOptions, say } from './dectalk';

--- a/dist/index.js
+++ b/dist/index.js
@@ -7,6 +7,8 @@ var __createBinding = (this && this.__createBinding) || (Object.create ? (functi
     o[k2] = m[k];
 }));
 exports.__esModule = true;
-exports.say = void 0;
+exports.say = exports.Speaker = exports.WaveEncoding = void 0;
 var dectalk_1 = require("./dectalk");
+__createBinding(exports, dectalk_1, "WaveEncoding");
+__createBinding(exports, dectalk_1, "Speaker");
 __createBinding(exports, dectalk_1, "say");

--- a/src/dectalk.ts
+++ b/src/dectalk.ts
@@ -1,7 +1,7 @@
-import { spawn } from 'child_process';
-import { readFileSync } from 'fs';
-import * as tmp from 'tmp';
-import * as os from 'os';
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { platform } from 'node:os';
+import { fileSync as makeTempFile } from 'tmp';
 
 export enum WaveEncoding {
     PCM_16bits_MONO_11KHz = 1,
@@ -62,11 +62,11 @@ type DecOptions = {
 
 export async function say(content:string, options?: DecOptions): Promise<Buffer> {
     return new Promise((res, rej) => {
-        const file = tmp.fileSync({prefix: 'dectalk', postfix: '.wav'});
+        const file = makeTempFile({prefix: 'dectalk', postfix: '.wav'});
         
         let dec;
         //Windows
-        if(os.platform() == "win32") {
+        if(platform() == "win32") {
                 var args: string[] = [];
                 if(options) {
                         if(options.EnableCommands)

--- a/src/dectalk.ts
+++ b/src/dectalk.ts
@@ -4,109 +4,109 @@ import { platform } from 'node:os';
 import { fileSync as makeTempFile } from 'tmp';
 
 export enum WaveEncoding {
-    PCM_16bits_MONO_11KHz = 1,
-    PCM_8bits_MONO_11KHz = 2,
-    MULAW_8bits_MONO_8KHz = 3
+	PCM_16bits_MONO_11KHz = 1,
+	PCM_8bits_MONO_11KHz = 2,
+	MULAW_8bits_MONO_8KHz = 3
 }
 
 type DecOptions = {
-    /**
-     * (_Linux only_)
-     * The encoding the wav file is
-     *
-     * PCM_16bits_MONO_11KHz = 1,
-     *
-     * PCM_8bits_MONO_11KHz = 2,
-     * 
-     * MULAW_8bits_MONO_8KHz = 3
-     */
-    WaveEncoding?: WaveEncoding,
+	/**
+	 * (_Linux only_)
+	 * The encoding the wav file is
+	 *
+	 * PCM_16bits_MONO_11KHz = 1,
+	 *
+	 * PCM_8bits_MONO_11KHz = 2,
+	 * 
+	 * MULAW_8bits_MONO_8KHz = 3
+	 */
+	WaveEncoding?: WaveEncoding,
 
-    /**
-     * (_Linux only_)
-     * The speed that he talks
-     */
-    SpeakRate?: number,
+	/**
+	 * (_Linux only_)
+	 * The speed that he talks
+	 */
+	SpeakRate?: number,
 
-    /**
-     * (_Linux only_)
-     * The voice of who talks. Default is 0
-     *
-     * 0. Paul (male)
-     * 1. Betty (female)
-     * 2. Harry (male, low pitch)
-     * 3. Frank (male, high pitch and hoarse)
-     * 4. Dennis (male, nasally)
-     * 5. Kid (child, high pitch)
-     * 6. Ursula (female, high pitch)
-     * 7. Rita (female, nasally)
-     * 8. Wendy (female, low pitch and hoarse)
-     *
-     * Any other numbers defaults to the 0 voice
-     */
-    SpeakerNumber?: number,
+	/**
+	 * (_Linux only_)
+	 * The voice of who talks. Default is 0
+	 *
+	 * 0. Paul (male)
+	 * 1. Betty (female)
+	 * 2. Harry (male, low pitch)
+	 * 3. Frank (male, high pitch and hoarse)
+	 * 4. Dennis (male, nasally)
+	 * 5. Kid (child, high pitch)
+	 * 6. Ursula (female, high pitch)
+	 * 7. Rita (female, nasally)
+	 * 8. Wendy (female, low pitch and hoarse)
+	 *
+	 * Any other numbers defaults to the 0 voice
+	 */
+	SpeakerNumber?: number,
 
-    /**
-     * Enable phoname commands
-     *
-     * example: "[bah<235,3>]"
-     *
-     * ### NOTE:
-     * - phonames can be enabled just by putting "[:PHONE ON]" at the start of the content
-     */
-    EnableCommands?: boolean
+	/**
+	 * Enable phoname commands
+	 *
+	 * example: "[bah<235,3>]"
+	 *
+	 * ### NOTE:
+	 * - phonames can be enabled just by putting "[:PHONE ON]" at the start of the content
+	 */
+	EnableCommands?: boolean
 
-}
+	}
 
 export async function say(content:string, options?: DecOptions): Promise<Buffer> {
-    return new Promise((res, rej) => {
-        const file = makeTempFile({prefix: 'dectalk', postfix: '.wav'});
-        
-        let dec;
-        //Windows
-        if(platform() == "win32") {
-                var args: string[] = [];
-                if(options) {
-                        if(options.EnableCommands)
-                                content = "[:PHONE ON]" + content;
-                }else {
-                        //Defaults
-                        // EnableCommands
-                        content = "[:PHONE ON]" + content;
-                }
-                args.push('-w', file.name);
-                //args.push('-d', __dirname + "\\..\\dtalk\\dtalk_us.dic");
-                args.push(content);
+	return new Promise((res, rej) => {
+		const file = makeTempFile({prefix: 'dectalk', postfix: '.wav'});
+		
+		let dec;
+		//Windows
+		if(platform() == "win32") {
+				var args: string[] = [];
+				if(options) {
+					if(options.EnableCommands)
+							content = "[:PHONE ON]" + content;
+				}else {
+					//Defaults
+					// EnableCommands
+					content = "[:PHONE ON]" + content;
+				}
+				args.push('-w', file.name);
+				//args.push('-d', __dirname + "\\..\\dtalk\\dtalk_us.dic");
+				args.push(content);
 
 
-                dec = spawn(__dirname + '\\..\\dtalk\\windows\\say.exe', args, {cwd: __dirname + '\\..\\dtalk\\windows'});
-        }
-        //Linux / Others
-        else {
-                var args: string[] = [];
-                if(options) {
-                        if(options.WaveEncoding)
-                                args.push('-e', options.WaveEncoding.toString());
-                        if(options.SpeakRate)
-                                args.push('-r', options.SpeakRate.toString());
-                        if(options.SpeakerNumber)
-                                args.push('-s', options.SpeakerNumber.toString());
-                        if(options.EnableCommands)
-                                content = "[:PHONE ON]" + content;
-                }else {
-                        //Defaults
-                        // EnableCommands
-                        content = "[:PHONE ON]" + content;
-                }
-                args.push('-a', content);
-                args.push('-fo', file.name);
+				dec = spawn(__dirname + '\\..\\dtalk\\windows\\say.exe', args, {cwd: __dirname + '\\..\\dtalk\\windows'});
+		}
+		//Linux / Others
+		else {
+				var args: string[] = [];
+				if(options) {
+					if(options.WaveEncoding)
+							args.push('-e', options.WaveEncoding.toString());
+					if(options.SpeakRate)
+							args.push('-r', options.SpeakRate.toString());
+					if(options.SpeakerNumber)
+							args.push('-s', options.SpeakerNumber.toString());
+					if(options.EnableCommands)
+							content = "[:PHONE ON]" + content;
+				}else {
+					//Defaults
+					// EnableCommands
+					content = "[:PHONE ON]" + content;
+				}
+				args.push('-a', content);
+				args.push('-fo', file.name);
 
 
-                dec = spawn(__dirname + '/../dtalk/linux/say_demo_us', args, {cwd: __dirname + '/../dtalk'});
-        }
+				dec = spawn(__dirname + '/../dtalk/linux/say_demo_us', args, {cwd: __dirname + '/../dtalk'});
+		}
 
-        dec.on('close', () => {
-            res(readFileSync(file.name));
-        })
-    }) 
+		dec.on('close', () => {
+			res(readFileSync(file.name));
+		})
+	}) 
 }

--- a/src/dectalk.ts
+++ b/src/dectalk.ts
@@ -9,7 +9,32 @@ export enum WaveEncoding {
 	MULAW_8bits_MONO_8KHz = 3
 }
 
-type DecOptions = {
+/**
+ * (_Linux only_)
+ * Different settings for voices.
+ */
+export enum Speaker {
+	/** Default male voice */
+	PAUL = 0,
+	/** Default female voice */
+	BETTY = 1,
+	/** Low-pitched male voice */
+	HARRY = 2,
+	/** High-pitched hoarse male voice */
+	FRANK = 3,
+	/** Nasally male voice */
+	DENNIS = 4,
+	/** High-pitched child voice */
+	KID = 5,
+	/** High-pitched female voice */
+	URSULA = 6,
+	/** Nasally female voice */
+	RITA = 7,
+	/** Low-pitched hoarse female voice */
+	WENDY = 8
+}
+
+export type DecOptions = {
 	/**
 	 * (_Linux only_)
 	 * The encoding the wav file is
@@ -24,27 +49,16 @@ type DecOptions = {
 
 	/**
 	 * (_Linux only_)
-	 * The speed that he talks
+	 * The speed that he talks in words-per-minute
+	 * Limit is 75 to 600
 	 */
 	SpeakRate?: number,
 
 	/**
 	 * (_Linux only_)
-	 * The voice of who talks. Default is 0
-	 *
-	 * 0. Paul (male)
-	 * 1. Betty (female)
-	 * 2. Harry (male, low pitch)
-	 * 3. Frank (male, high pitch and hoarse)
-	 * 4. Dennis (male, nasally)
-	 * 5. Kid (child, high pitch)
-	 * 6. Ursula (female, high pitch)
-	 * 7. Rita (female, nasally)
-	 * 8. Wendy (female, low pitch and hoarse)
-	 *
-	 * Any other numbers defaults to the 0 voice
+	 * The voice of who talks. Default is PAUL (0)
 	 */
-	SpeakerNumber?: number,
+	Speaker?: Speaker,
 
 	/**
 	 * Enable phoname commands
@@ -93,8 +107,8 @@ export async function say(content:string, options?: DecOptions): Promise<Buffer>
 						args.push('-e', options.WaveEncoding.toString());
 				if(options.SpeakRate)
 						args.push('-r', options.SpeakRate.toString());
-				if(options.SpeakerNumber)
-						args.push('-s', options.SpeakerNumber.toString());
+				if(options.Speaker)
+						args.push('-s', options.Speaker.toString());
 				if(options.EnableCommands)
 						content = "[:PHONE ON]" + content;
 			} else {

--- a/src/dectalk.ts
+++ b/src/dectalk.ts
@@ -75,11 +75,11 @@ export async function say(content:string, options?: DecOptions): Promise<Buffer>
                         content = "[:PHONE ON]" + content;
                 }
                 args.push('-w', file.name);
-                //args.push('-d', __dirname + "/../dtalk/dtalk_us.dic");
+                //args.push('-d', __dirname + "\\..\\dtalk\\dtalk_us.dic");
                 args.push(content);
 
 
-                dec = spawn(__dirname + '/../dtalk/windows/say.exe', args, {cwd: __dirname + '/../dtalk/windows'});
+                dec = spawn(__dirname + '\\..\\dtalk\\windows\\say.exe', args, {cwd: __dirname + '\\..\\dtalk\\windows'});
         }
         //Linux / Others
         else {

--- a/src/dectalk.ts
+++ b/src/dectalk.ts
@@ -64,7 +64,7 @@ export async function say(content:string, options?: DecOptions): Promise<Buffer>
 		
 		let dec;
 		// Windows
-		if (platform() == "win32") {
+		if (platform() === "win32") {
 			var args: string[] = [];
 			if (options) {
 				if(options.EnableCommands)
@@ -81,7 +81,11 @@ export async function say(content:string, options?: DecOptions): Promise<Buffer>
 
 			dec = spawn(__dirname + '\\..\\dtalk\\windows\\say.exe', args, {cwd: __dirname + '\\..\\dtalk\\windows'});
 		}
-		// Linux / Others
+		// Mac is NOT supported
+		else if (platform() === "darwin") {
+			rej('Dectalk is not supported on Mac');
+		}
+		// Linux
 		else {
 			var args: string[] = [];
 			if (options) {

--- a/src/dectalk.ts
+++ b/src/dectalk.ts
@@ -56,53 +56,53 @@ type DecOptions = {
 	 */
 	EnableCommands?: boolean
 
-	}
+}
 
 export async function say(content:string, options?: DecOptions): Promise<Buffer> {
 	return new Promise((res, rej) => {
 		const file = makeTempFile({prefix: 'dectalk', postfix: '.wav'});
 		
 		let dec;
-		//Windows
-		if(platform() == "win32") {
-				var args: string[] = [];
-				if(options) {
-					if(options.EnableCommands)
-							content = "[:PHONE ON]" + content;
-				}else {
-					//Defaults
-					// EnableCommands
-					content = "[:PHONE ON]" + content;
-				}
-				args.push('-w', file.name);
-				//args.push('-d', __dirname + "\\..\\dtalk\\dtalk_us.dic");
-				args.push(content);
+		// Windows
+		if (platform() == "win32") {
+			var args: string[] = [];
+			if (options) {
+				if(options.EnableCommands)
+						content = "[:PHONE ON]" + content;
+			} else {
+				//Defaults
+				// EnableCommands
+				content = "[:PHONE ON]" + content;
+			}
+			args.push('-w', file.name);
+			//args.push('-d', __dirname + "\\..\\dtalk\\dtalk_us.dic");
+			args.push(content);
 
 
-				dec = spawn(__dirname + '\\..\\dtalk\\windows\\say.exe', args, {cwd: __dirname + '\\..\\dtalk\\windows'});
+			dec = spawn(__dirname + '\\..\\dtalk\\windows\\say.exe', args, {cwd: __dirname + '\\..\\dtalk\\windows'});
 		}
-		//Linux / Others
+		// Linux / Others
 		else {
-				var args: string[] = [];
-				if(options) {
-					if(options.WaveEncoding)
-							args.push('-e', options.WaveEncoding.toString());
-					if(options.SpeakRate)
-							args.push('-r', options.SpeakRate.toString());
-					if(options.SpeakerNumber)
-							args.push('-s', options.SpeakerNumber.toString());
-					if(options.EnableCommands)
-							content = "[:PHONE ON]" + content;
-				}else {
-					//Defaults
-					// EnableCommands
-					content = "[:PHONE ON]" + content;
-				}
-				args.push('-a', content);
-				args.push('-fo', file.name);
+			var args: string[] = [];
+			if (options) {
+				if(options.WaveEncoding)
+						args.push('-e', options.WaveEncoding.toString());
+				if(options.SpeakRate)
+						args.push('-r', options.SpeakRate.toString());
+				if(options.SpeakerNumber)
+						args.push('-s', options.SpeakerNumber.toString());
+				if(options.EnableCommands)
+						content = "[:PHONE ON]" + content;
+			} else {
+				//Defaults
+				// EnableCommands
+				content = "[:PHONE ON]" + content;
+			}
+			args.push('-a', content);
+			args.push('-fo', file.name);
 
 
-				dec = spawn(__dirname + '/../dtalk/linux/say_demo_us', args, {cwd: __dirname + '/../dtalk'});
+			dec = spawn(__dirname + '/../dtalk/linux/say_demo_us', args, {cwd: __dirname + '/../dtalk'});
 		}
 
 		// Reject if dectalk failed to start
@@ -116,7 +116,8 @@ export async function say(content:string, options?: DecOptions): Promise<Buffer>
 
 		dec.on('close', code => {
 			// Reject if dectalk was not successful
-			if (code !== 0) rej(`Dectalk exited with code ${code}`);
+			if (code !== 0)
+				rej(`Dectalk exited with code ${code}`);
 
 			res(readFileSync(file.name));
 		})

--- a/src/dectalk.ts
+++ b/src/dectalk.ts
@@ -105,7 +105,19 @@ export async function say(content:string, options?: DecOptions): Promise<Buffer>
 				dec = spawn(__dirname + '/../dtalk/linux/say_demo_us', args, {cwd: __dirname + '/../dtalk'});
 		}
 
-		dec.on('close', () => {
+		// Reject if dectalk failed to start
+		dec.on('error', error => {
+			rej(`Failed to start dectalk\n${error}`);
+		});
+
+		// Redirect dectalk output to the console
+		dec.stdout.on('data', console.log);
+		dec.stderr.on('data', console.error);
+
+		dec.on('close', code => {
+			// Reject if dectalk was not successful
+			if (code !== 0) rej(`Dectalk exited with code ${code}`);
+
 			res(readFileSync(file.name));
 		})
 	}) 

--- a/src/dectalk.ts
+++ b/src/dectalk.ts
@@ -30,19 +30,17 @@ type DecOptions = {
 
     /**
      * (_Linux only_)
-     * The voice of who talks
+     * The voice of who talks. Default is 0
      *
-     * Here is what i think they are
-     *
-     * -> 0. Default voice
-     * 1. Female voice
-     * 2. Low pitch guy
-     * 3. Another Female voice?
-     * 4. Almost Default voice (a little lower pitch)
-     * 5. Female very high pitch
-     * 6. Female high pitch (like the previouse but lower)
-     * 7. Another male voice
-     * 8. Another female voice
+     * 0. Paul (male)
+     * 1. Betty (female)
+     * 2. Harry (male, low pitch)
+     * 3. Frank (male, high pitch and hoarse)
+     * 4. Dennis (male, nasally)
+     * 5. Kid (child, high pitch)
+     * 6. Ursula (female, high pitch)
+     * 7. Rita (female, nasally)
+     * 8. Wendy (female, low pitch and hoarse)
      *
      * Any other numbers defaults to the 0 voice
      */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export {say} from './dectalk'
+export { WaveEncoding, Speaker, DecOptions, say  } from './dectalk'


### PR DESCRIPTION
This is a really cool module and I've had a lot of fun with it.

Based on my experiences, I've made some small changes to the code.

Change list:
- replaced all space indents with tabs (this is why git says I changed nearly every line)
- modified imports to fit typescript standards
- improved support for windows filepaths
- added Speaker enum with voice definitions (I did some research to find out what the voices were)
- added more error checking
- added child process output redirection (this is super useful if dectalk throws errors)
- blocked macOS and added a comment in the README (I did a LOT of testing and confirmed that dectalk doesn't support mac)

If you decide to merge my changes, I recommend squashing my commits so your version history stays cleaner.