### PR TITLE
FIX: return after rejecting

### DIFF
--- a/dist/dectalk.js
+++ b/dist/dectalk.js
@@ -98,6 +98,7 @@ function say(content, options) {
                     // Mac is NOT supported
                     else if ((0, node_os_1.platform)() === "darwin") {
                         rej('Dectalk is not supported on Mac');
+                        return;
                     }
                     // Linux
                     else {
@@ -121,20 +122,29 @@ function say(content, options) {
                         args.push('-fo', file.name);
                         dec = (0, node_child_process_1.spawn)(__dirname + '/../dtalk/linux/say_demo_us', args, { cwd: __dirname + '/../dtalk' });
                     }
+                    var exited = false;
                     // Reject if dectalk failed to start
                     dec.on('error', function (error) {
+                        if (exited) {
+                            return;
+                        }
                         rej("Failed to start dectalk\n" + error);
+                        exited = true;
                     });
                     // Redirect dectalk output to the console
                     dec.stdout.on('data', console.log);
                     dec.stderr.on('data', console.error);
                     dec.on('close', function (code) {
+                        if (exited) {
+                            return;
+                        }
                         // Reject if dectalk was not successful
                         if (code !== 0) {
                             rej("Dectalk exited with code " + code);
                             return;
                         }
                         res((0, node_fs_1.readFileSync)(file.name));
+                        exited = true;
                     });
                 })];
         });

--- a/dist/dectalk.js
+++ b/dist/dectalk.js
@@ -130,8 +130,10 @@ function say(content, options) {
                     dec.stderr.on('data', console.error);
                     dec.on('close', function (code) {
                         // Reject if dectalk was not successful
-                        if (code !== 0)
+                        if (code !== 0) {
                             rej("Dectalk exited with code " + code);
+                            return;
+                        }
                         res((0, node_fs_1.readFileSync)(file.name));
                     });
                 })];

--- a/src/dectalk.ts
+++ b/src/dectalk.ts
@@ -134,8 +134,11 @@ export async function say(content:string, options?: DecOptions): Promise<Buffer>
 
 		dec.on('close', code => {
 			// Reject if dectalk was not successful
-			if (code !== 0)
+			if (code !== 0){
 				rej(`Dectalk exited with code ${code}`);
+
+				return;
+			}
 
 			res(readFileSync(file.name));
 		})

--- a/src/dectalk.ts
+++ b/src/dectalk.ts
@@ -98,6 +98,8 @@ export async function say(content:string, options?: DecOptions): Promise<Buffer>
 		// Mac is NOT supported
 		else if (platform() === "darwin") {
 			rej('Dectalk is not supported on Mac');
+
+			return;
 		}
 		// Linux
 		else {
@@ -123,9 +125,17 @@ export async function say(content:string, options?: DecOptions): Promise<Buffer>
 			dec = spawn(__dirname + '/../dtalk/linux/say_demo_us', args, {cwd: __dirname + '/../dtalk'});
 		}
 
+		let exited = false;
+
 		// Reject if dectalk failed to start
 		dec.on('error', error => {
+			if(exited){
+				return;
+			}
+
 			rej(`Failed to start dectalk\n${error}`);
+
+			exited = true;
 		});
 
 		// Redirect dectalk output to the console
@@ -133,6 +143,10 @@ export async function say(content:string, options?: DecOptions): Promise<Buffer>
 		dec.stderr.on('data', console.error);
 
 		dec.on('close', code => {
+			if(exited){
+				return;
+			}
+
 			// Reject if dectalk was not successful
 			if (code !== 0){
 				rej(`Dectalk exited with code ${code}`);
@@ -141,6 +155,8 @@ export async function say(content:string, options?: DecOptions): Promise<Buffer>
 			}
 
 			res(readFileSync(file.name));
+			
+			exited = true;
 		})
 	}) 
 }


### PR DESCRIPTION
calling resolve or reject multiple times is bad practice. while it doesn't have any impact on the outcome necessarily, by not returning we are doing more computation than is necessary.

since both the close and error events can fire (https://nodejs.org/api/child_process.html#event-close) i added a flag to track if the process has exited or not.